### PR TITLE
Support for reading yml extension

### DIFF
--- a/converter/spec_upgrade.py
+++ b/converter/spec_upgrade.py
@@ -14,8 +14,12 @@ class MetricFLowConfig:
         """
         initalize MetricFlowConfigs from a directory of semantic models and metrics.
         """
-        model_configs = glob.glob(f'{model_dir_path}/*.yaml')
-        metric_configs = glob.glob(f'{metric_dir_path}/*.yaml')
+        model_configs = glob.glob(f"{model_dir_path}/*.yaml") + glob.glob(
+            f"{model_dir_path}/*.yml"
+        )
+        metric_configs = glob.glob(f"{metric_dir_path}/*.yaml") + glob.glob(
+            f"{metric_dir_path}/*.yml"
+        )
         for model in model_configs:
             with open(model) as stream:
                 self.models.append(yaml.safe_load(stream))


### PR DESCRIPTION
Note, the output files that are created will still have the `.yaml` extension due to this https://github.com/dbt-labs/dbt-converter/blob/5789af60e726d8ba0b2be97dcfc937024dc640a6/converter/dbt_metrics_to_semantic_model_converter.py#L66. We may decide to make this configurable in the future.